### PR TITLE
Add multi-provider CLI chatbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM continuumio/miniconda3:latest
+
+COPY environment.yml /tmp/environment.yml
+RUN conda env create -f /tmp/environment.yml
+SHELL ["/bin/bash", "-c"]
+RUN echo "conda activate cli-chatbot" > /etc/profile.d/conda.sh
+ENV PATH /opt/conda/envs/cli-chatbot/bin:$PATH
+
+WORKDIR /app
+COPY . /app
+
+CMD ["python", "chatbot.py", "chat"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Basic-CLI-ChatBot
-A simple implementation of a basic chatbot with different providers and upgraded thinking models compatibility
+
+This project provides a simple command line chatbot supporting several AI
+providers with streaming responses and a colorful interface. It includes
+configuration files for running in a Conda environment or inside Docker.
+
+## Usage
+
+1. **Create the environment**
+
+   ```bash
+   conda env create -f environment.yml
+   conda activate cli-chatbot
+   ```
+
+2. **Run the chatbot**
+
+   ```bash
+   python chatbot.py chat
+   ```
+
+Environment variables such as `OPENAI_API_KEY` can be set to avoid entering
+API keys on every run.
+
+### Docker
+
+To build and run with Docker:
+
+```bash
+docker build -t cli-chatbot .
+docker run -it cli-chatbot
+```

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""CLI chatbot supporting multiple providers with streaming output."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from typing import AsyncGenerator, List, Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
+from rich.live import Live
+from rich.spinner import Spinner
+from prompt_toolkit import prompt
+
+# Provider libraries. These are imported lazily in provider classes
+import openai
+import anthropic
+import google.generativeai as genai
+from groq import Groq
+
+console = Console()
+
+class Provider(str, Enum):
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    GEMINI = "gemini"
+    DEEPSEEK = "deepseek"
+    GROQ = "groq"
+
+@dataclass
+class ModelInfo:
+    name: str
+    display_name: str
+    is_thinking: bool = False
+    max_tokens: int = 4096
+
+PROVIDER_MODELS: dict[Provider, List[ModelInfo]] = {
+    Provider.OPENAI: [
+        ModelInfo("gpt-4o", "GPT-4o", max_tokens=128000),
+        ModelInfo("gpt-4", "GPT-4"),
+        ModelInfo("o3", "o3", is_thinking=True),
+    ],
+    Provider.ANTHROPIC: [
+        ModelInfo("claude-3-sonnet-20240229", "Claude 3 Sonnet"),
+        ModelInfo("claude-3-haiku-20240307", "Claude 3 Haiku"),
+    ],
+    Provider.GEMINI: [
+        ModelInfo("gemini-pro", "Gemini Pro"),
+    ],
+    Provider.DEEPSEEK: [
+        ModelInfo("deepseek-chat", "DeepSeek Chat"),
+        ModelInfo("deepseek-reasoner", "DeepSeek R1", is_thinking=True),
+    ],
+    Provider.GROQ: [
+        ModelInfo("llama3-70b-8192", "Llama3 70B"),
+    ],
+}
+
+class ChatbotProvider:
+    def __init__(self, api_key: str, model: ModelInfo):
+        self.api_key = api_key
+        self.model = model
+        self.history: List[dict[str, str]] = []
+
+    def add_to_history(self, role: str, content: str) -> None:
+        self.history.append({"role": role, "content": content})
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        raise NotImplementedError
+
+class OpenAIProvider(ChatbotProvider):
+    def __init__(self, api_key: str, model: ModelInfo):
+        super().__init__(api_key, model)
+        self.client = openai.OpenAI(api_key=api_key)
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        self.add_to_history("user", message)
+        try:
+            stream = self.client.chat.completions.create(
+                model=self.model.name,
+                messages=self.history,
+                stream=True,
+                max_tokens=self.model.max_tokens,
+            )
+            full = ""
+            for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if not delta:
+                    continue
+                full += delta
+                yield delta
+            self.add_to_history("assistant", full)
+        except Exception as e:  # pragma: no cover - network errors
+            yield f"Error: {e}"
+
+class AnthropicProvider(ChatbotProvider):
+    def __init__(self, api_key: str, model: ModelInfo):
+        super().__init__(api_key, model)
+        self.client = anthropic.Anthropic(api_key=api_key)
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        self.add_to_history("user", message)
+        try:
+            messages = [m for m in self.history if m["role"] != "system"]
+            with self.client.messages.stream(
+                model=self.model.name,
+                messages=messages,
+                max_tokens=self.model.max_tokens,
+            ) as stream:
+                full = ""
+                for text in stream.text_stream:
+                    full += text
+                    yield text
+                self.add_to_history("assistant", full)
+        except Exception as e:  # pragma: no cover
+            yield f"Error: {e}"
+
+class GeminiProvider(ChatbotProvider):
+    def __init__(self, api_key: str, model: ModelInfo):
+        super().__init__(api_key, model)
+        genai.configure(api_key=api_key)
+        self.model_client = genai.GenerativeModel(model.name)
+        self.chat = self.model_client.start_chat(history=[])
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        try:
+            resp = self.chat.send_message(
+                message,
+                stream=True,
+                generation_config=genai.types.GenerationConfig(max_output_tokens=self.model.max_tokens),
+            )
+            for chunk in resp:
+                if chunk.text:
+                    yield chunk.text
+        except Exception as e:  # pragma: no cover
+            yield f"Error: {e}"
+
+class DeepSeekProvider(ChatbotProvider):
+    def __init__(self, api_key: str, model: ModelInfo):
+        super().__init__(api_key, model)
+        self.client = openai.OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        self.add_to_history("user", message)
+        try:
+            stream = self.client.chat.completions.create(
+                model=self.model.name,
+                messages=self.history,
+                stream=True,
+                max_tokens=self.model.max_tokens,
+            )
+            full = ""
+            hide = False
+            for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if not delta:
+                    continue
+                if self.model.is_thinking:
+                    if "<thinking>" in delta:
+                        hide = True
+                        continue
+                    if "</thinking>" in delta:
+                        hide = False
+                        continue
+                    if hide:
+                        continue
+                full += delta
+                yield delta
+            self.add_to_history("assistant", full)
+        except Exception as e:  # pragma: no cover
+            yield f"Error: {e}"
+
+class GroqProvider(ChatbotProvider):
+    def __init__(self, api_key: str, model: ModelInfo):
+        super().__init__(api_key, model)
+        self.client = Groq(api_key=api_key)
+
+    async def stream_response(self, message: str) -> AsyncGenerator[str, None]:
+        self.add_to_history("user", message)
+        try:
+            stream = self.client.chat.completions.create(
+                model=self.model.name,
+                messages=self.history,
+                stream=True,
+                max_tokens=self.model.max_tokens,
+            )
+            full = ""
+            for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if not delta:
+                    continue
+                full += delta
+                yield delta
+            self.add_to_history("assistant", full)
+        except Exception as e:  # pragma: no cover
+            yield f"Error: {e}"
+
+class ChatBot:
+    def __init__(self):
+        self.provider: Optional[ChatbotProvider] = None
+        self.provider_type: Optional[Provider] = None
+        self.model: Optional[ModelInfo] = None
+
+    def display_welcome(self) -> None:
+        text = Text()
+        text.append("Multi-Provider CLI Chatbot\n", style="bold blue")
+        text.append("Supports OpenAI, Anthropic, Gemini, DeepSeek, Groq", style="green")
+        console.print(Panel(text, title="Welcome", border_style="blue"))
+
+    def select_provider_and_model(self) -> tuple[Provider, ModelInfo]:
+        providers = list(Provider)
+        console.print("\nProviders:", style="bold cyan")
+        for i, p in enumerate(providers, 1):
+            console.print(f"  {i}. {p.value}")
+        while True:
+            try:
+                choice = int(prompt("Select provider: ")) - 1
+                if 0 <= choice < len(providers):
+                    provider = providers[choice]
+                    break
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                pass
+            console.print("Invalid choice", style="red")
+
+        models = PROVIDER_MODELS[provider]
+        console.print(f"\nModels for {provider.value}:", style="bold cyan")
+        for i, m in enumerate(models, 1):
+            mark = " 🧠" if m.is_thinking else ""
+            console.print(f"  {i}. {m.display_name}{mark}")
+        while True:
+            try:
+                choice = int(prompt("Select model: ")) - 1
+                if 0 <= choice < len(models):
+                    model = models[choice]
+                    break
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                pass
+            console.print("Invalid choice", style="red")
+        return provider, model
+
+    def get_api_key(self, provider: Provider) -> str:
+        env_name = f"{provider.value.upper()}_API_KEY"
+        key = os.getenv(env_name)
+        if key:
+            console.print(f"Using {env_name} from environment", style="green")
+            return key
+        key = prompt("API key: ", is_password=True)
+        if not key:
+            console.print("API key required", style="red")
+            sys.exit(1)
+        return key
+
+    def create_provider(self, provider: Provider, key: str, model: ModelInfo) -> ChatbotProvider:
+        mapping = {
+            Provider.OPENAI: OpenAIProvider,
+            Provider.ANTHROPIC: AnthropicProvider,
+            Provider.GEMINI: GeminiProvider,
+            Provider.DEEPSEEK: DeepSeekProvider,
+            Provider.GROQ: GroqProvider,
+        }
+        cls = mapping[provider]
+        return cls(key, model)
+
+    async def chat_loop(self) -> None:
+        console.print("\nType 'quit' to exit", style="green")
+        if self.model and self.model.is_thinking:
+            console.print("Thinking model active", style="yellow")
+        while True:
+            user = prompt("You: ").strip()
+            if user.lower() in {"quit", "exit"}:
+                break
+            if not user:
+                continue
+            console.print(Panel(Text(user, style="blue"), title="You", border_style="blue"))
+            console.print("AI:", style="bold green")
+            if self.model and self.model.is_thinking:
+                with Live(Spinner("dots", text="Thinking...")):
+                    await asyncio.sleep(0.5)
+            out = Text()
+            with Live(out, refresh_per_second=10) as live:
+                async for chunk in self.provider.stream_response(user):
+                    out.append(chunk, style="green")
+                    live.update(out)
+            console.print(Panel(out, title="Assistant", border_style="green"))
+
+    async def run(self) -> None:
+        self.display_welcome()
+        self.provider_type, self.model = self.select_provider_and_model()
+        key = self.get_api_key(self.provider_type)
+        self.provider = self.create_provider(self.provider_type, key, self.model)
+        console.print(f"Connected to {self.provider_type.value}", style="green")
+        await self.chat_loop()
+
+app = typer.Typer(help="CLI Chatbot")
+
+@app.command()
+def chat():
+    chatbot = ChatBot()
+    asyncio.run(chatbot.run())
+
+if __name__ == "__main__":
+    app()

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: cli-chatbot
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - openai
+      - anthropic
+      - google-generativeai
+      - groq
+      - rich
+      - typer
+      - prompt-toolkit
+      - pytest
+      - pytest-asyncio

--- a/test_chatbot.py
+++ b/test_chatbot.py
@@ -1,0 +1,112 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from chatbot import (
+    ChatBot,
+    OpenAIProvider,
+    AnthropicProvider,
+    GeminiProvider,
+    DeepSeekProvider,
+    GroqProvider,
+    ModelInfo,
+    Provider,
+)
+
+@pytest.fixture
+def mock_model():
+    return ModelInfo("test-model", "Test Model")
+
+@pytest.fixture
+def thinking_model():
+    return ModelInfo("test-thinking", "Thinking Model", is_thinking=True)
+
+
+def test_provider_initialization(mock_model):
+    key = "k"
+    for cls in [OpenAIProvider, AnthropicProvider, GeminiProvider, DeepSeekProvider, GroqProvider]:
+        with patch.object(cls, "__init__", return_value=None) as init:
+            cls(key, mock_model)
+            init.assert_called()
+
+@pytest.mark.asyncio
+async def test_openai_stream(mock_model):
+    mock_stream = [
+        Mock(choices=[Mock(delta=Mock(content="a"))]),
+        Mock(choices=[Mock(delta=Mock(content="b"))]),
+    ]
+    with patch("openai.OpenAI") as m:
+        m.return_value.chat.completions.create.return_value = mock_stream
+        provider = OpenAIProvider("k", mock_model)
+        provider.client = m.return_value
+        out = []
+        async for chunk in provider.stream_response("hi"):
+            out.append(chunk)
+        assert out == ["a", "b"]
+
+@pytest.mark.asyncio
+async def test_deepseek_thinking(thinking_model):
+    mock_stream = [
+        Mock(choices=[Mock(delta=Mock(content="<thinking>"))]),
+        Mock(choices=[Mock(delta=Mock(content="hidden"))]),
+        Mock(choices=[Mock(delta=Mock(content="</thinking>"))]),
+        Mock(choices=[Mock(delta=Mock(content="final"))]),
+    ]
+    with patch("openai.OpenAI") as m:
+        m.return_value.chat.completions.create.return_value = mock_stream
+        provider = DeepSeekProvider("k", thinking_model)
+        provider.client = m.return_value
+        out = []
+        async for chunk in provider.stream_response("hi"):
+            out.append(chunk)
+        assert out == ["final"]
+
+
+def test_history(mock_model):
+    p = OpenAIProvider("k", mock_model)
+    p.client = Mock()
+    p.add_to_history("user", "hi")
+    p.add_to_history("assistant", "yo")
+    assert p.history[0]["role"] == "user"
+    assert p.history[1]["role"] == "assistant"
+
+@pytest.mark.asyncio
+async def test_error_handling(mock_model):
+    with patch("openai.OpenAI") as m:
+        m.return_value.chat.completions.create.side_effect = Exception("boom")
+        provider = OpenAIProvider("k", mock_model)
+        provider.client = m.return_value
+        out = []
+        async for chunk in provider.stream_response("hi"):
+            out.append(chunk)
+        assert any("Error" in c for c in out)
+
+
+def test_get_api_key_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "123")
+    bot = ChatBot()
+    assert bot.get_api_key(Provider.OPENAI) == "123"
+
+
+class DummyBenchmark:
+    async def __call__(self, func):
+        return await func()
+
+@pytest.mark.asyncio
+async def test_stream_perf(mock_model):
+    mock_stream = [Mock(choices=[Mock(delta=Mock(content=f"c{i}"))]) for i in range(10)]
+    with patch("openai.OpenAI") as m:
+        m.return_value.chat.completions.create.return_value = mock_stream
+        provider = OpenAIProvider("k", mock_model)
+        provider.client = m.return_value
+        bench = DummyBenchmark()
+
+        async def _stream():
+            out = []
+            async for chunk in provider.stream_response("hi"):
+                out.append(chunk)
+            return out
+
+        result = await bench(_stream)
+        assert len(result) == 10


### PR DESCRIPTION
## Summary
- implement `chatbot.py` with support for OpenAI, Anthropic, Gemini, DeepSeek and Groq providers
- add unit tests covering provider logic and CLI helpers
- add Conda environment and Dockerfile for containerised usage
- update README with usage instructions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a27dd2888330af0fa521c6d40bf3