### PR TITLE
Add MCP provider support with tool execution capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest
 pytest-asyncio
 python-dotenv
 nest-asyncio
+aiohttp


### PR DESCRIPTION


## Summary
This PR adds support for MCP (Model Control Protocol) provider, enabling:
- Connection to MCP servers
- Execution of external tools through standardized protocol
- Streaming responses with tool integration

## Key Features
1. **MCP Provider Class**:
   - Asynchronous HTTP communication
   - Tool execution framework
   - Configurable base URL via `MCP_BASE_URL` environment variable

2. **New Models**:
   - MCP Standard (4096 tokens)
   - MCP Advanced (8192 tokens)
   - MCP Enterprise (32768 tokens)

3. **Tool Execution**:
   ```json
   {
     "type": "function",
     "function": {
       "name": "execute_tool",
       "description": "Execute a tool via MCP protocol",
       "parameters": {
         "type": "object",
         "properties": {
           "tool_name": {"type": "string"},
           "parameters": {"type": "object"}
         },
         "required": ["tool_name"]
       }
     }
   }
   ```

## Usage
1. Set environment variables:
   ```bash
   export MCP_API_KEY="your_api_key"
   # Optional: export MCP_BASE_URL="https://custom.mcp.server"
   ```
2. Run chatbot:
   ```bash
   python chatbot.py chat
   ```
3. Select MCP provider and model

## Dependencies
- Added `aiohttp` to requirements.txt

## Testing
- Syntax verification passed
- Manual testing with sample MCP server recommended

